### PR TITLE
JEPAのアーキテクチャを汎用化

### DIFF
--- a/src/sample/models/components/positional_embeddings.py
+++ b/src/sample/models/components/positional_embeddings.py
@@ -2,13 +2,12 @@
 
 import numpy as np
 import numpy.typing as npt
+import torch
 
 from sample.utils import size_2d, size_2d_to_int_tuple
 
 
-def get_2d_positional_embeddings(
-    embed_dim: int, grid_size: size_2d
-) -> npt.NDArray[np.float64]:
+def get_2d_positional_embeddings(embed_dim: int, grid_size: size_2d) -> torch.Tensor:
     """
     Args:
         embed_dim: dim of positional embeddings.
@@ -25,7 +24,7 @@ def get_2d_positional_embeddings(
     positional_embeddings = _get_2d_sincos_positional_embeddings_from_grid(
         embed_dim, grid
     )
-    return positional_embeddings
+    return torch.from_numpy(positional_embeddings).float()
 
 
 def _get_2d_sincos_positional_embeddings_from_grid(

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -97,20 +97,20 @@ class Encoder(nn.Module):
 
     @override
     def forward(
-        self, images: torch.Tensor, masks: torch.Tensor | None = None
+        self, data: torch.Tensor, masks: torch.Tensor | None = None
     ) -> torch.Tensor:
-        """Encode input images into latents, applying masks if provided.
+        """Encode input data into latents, applying masks if provided.
 
         Args:
-            images: Input images with shape [batch_size, 3, height, width]
+            data: Input data
             masks: Boolean masks for images embedded as patches with shape
                 [batch_size, n_patches]. True values indicate masked patches.
 
         Returns:
             Encoded latents with shape [batch_size, n_patches, out_dim]
         """
-        # Patchify input images
-        x = self.patchfier(images)
+        # Patchify input data
+        x = self.patchfier(data)
         # x: [batch_size, n_patches, embed_dim]
 
         # Apply mask if provided
@@ -138,9 +138,9 @@ class Encoder(nn.Module):
 
     @override
     def __call__(
-        self, images: torch.Tensor, masks: torch.Tensor | None = None
+        self, data: torch.Tensor, masks: torch.Tensor | None = None
     ) -> torch.Tensor:
-        return super().__call__(images, masks)
+        return super().__call__(data, masks)
 
     def clone(self) -> Self:
         """Clone model for creating target or context encoder."""

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -67,11 +67,8 @@ class Encoder(nn.Module):
         # define mask token_vector
         self.mask_token_vector = nn.Parameter(torch.empty(hidden_dim))
 
-        self.positional_encodings: torch.Tensor
-        self.register_buffer(
-            "positional_encodings",
-            positional_encodings.unsqueeze(0),
-        )
+        self.register_buffer("positional_encodings", None)
+        self.positional_encodings = positional_encodings.unsqueeze(0)
 
         # define transformer
         self.transformer = Transformer(
@@ -192,8 +189,8 @@ class Predictor(nn.Module):
         self.prediction_token_vector = nn.Parameter(torch.empty(hidden_dim))
 
         # define positional encodings
-        self.positional_encodings: torch.Tensor
-        self.register_buffer("positional_encodings", positional_encodings.unsqueeze(0))
+        self.register_buffer("positional_encodings", None)
+        self.positional_encodings = positional_encodings.unsqueeze(0)
 
         # define transformer
         self.transformer = Transformer(

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -271,7 +271,7 @@ class Predictor(nn.Module):
         return super().__call__(latents, targets)
 
 
-class AveragePoolInfer:
+class AveragePoolInfer2d:
     """Applies average pooling to encoded image patches from a JEPA encoder."""
 
     def __init__(

--- a/src/sample/trainers/jepa.py
+++ b/src/sample/trainers/jepa.py
@@ -289,7 +289,7 @@ class JEPATrainer(TorchTrainer):
 
 
 class MultiBlockMaskCollator2d:
-    """Image-JEPA collator function for providing boolean mask tensors.
+    """JEPA collator function for providing boolean mask tensors.
 
     This collator creates boolean masks for both the context encoder and predictor target.
     It's designed to work with the Image-JEPA (Image Joint Embedding Predictive Architecture) model.
@@ -297,8 +297,6 @@ class MultiBlockMaskCollator2d:
     The masks are boolean tensors where:
     - True values indicate patches to be masked (ignored)
     - False values indicate patches to be processed or predicted
-
-    This differs from IJEPAMaskCollator which uses integer indices for masked patches.
     """
 
     def __init__(

--- a/tests/sample/models/components/test_positional_embeddings.py
+++ b/tests/sample/models/components/test_positional_embeddings.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pytest
+import torch
 
 from sample.models.components.positional_embeddings import (
     get_2d_positional_embeddings,
@@ -45,6 +45,6 @@ def test_get_2d_positional_embeddings(
         positional_embeddings.shape[1] == expected_grid_size_w
     ), "grid size (width) mismatch."
     assert positional_embeddings.shape[2] == embed_dim, "dim mismatch."
-    assert np.all(
-        np.abs(positional_embeddings) <= 1.0
+    assert torch.all(
+        torch.abs(positional_embeddings) <= 1.0
     ), "some invalid values of sin and cos function"

--- a/tests/sample/models/test_jepa.py
+++ b/tests/sample/models/test_jepa.py
@@ -1,8 +1,9 @@
 import pytest
 import torch
 
-from sample.models.image_jepa import AveragePoolInfer, Encoder, Predictor
-from sample.utils import size_2d_to_int_tuple
+from sample.models.components.patch_embedding import PatchEmbedding
+from sample.models.components.positional_embeddings import get_2d_positional_embeddings
+from sample.models.jepa import AveragePoolInfer, Encoder, Predictor
 
 
 class TestEncoder:
@@ -15,9 +16,16 @@ class TestEncoder:
         self, batch_size, img_size, patch_size, hidden_dim, embed_dim
     ):
         """Test Encoder's forward pass without mask."""
+        n_patches = (img_size // patch_size) ** 2
+        patchfier = PatchEmbedding(patch_size, 3, hidden_dim)
+        positional_encodings = get_2d_positional_embeddings(
+            hidden_dim, (img_size // patch_size, img_size // patch_size)
+        ).reshape(n_patches, hidden_dim)
+
         encoder = Encoder(
-            img_size=img_size,
-            patch_size=patch_size,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             hidden_dim=hidden_dim,
             embed_dim=embed_dim,
             depth=2,
@@ -27,7 +35,6 @@ class TestEncoder:
         images = torch.randn(batch_size, 3, img_size, img_size)
         encoded = encoder(images)
 
-        n_patches = (img_size // patch_size) ** 2
         assert encoded.shape == (batch_size, n_patches, embed_dim)
 
     @pytest.mark.parametrize("batch_size", [1])
@@ -36,9 +43,16 @@ class TestEncoder:
     @pytest.mark.parametrize("mask_ratio", [0.25])
     def test_forward_with_mask(self, batch_size, img_size, patch_size, mask_ratio):
         """Test Encoder's forward pass with mask."""
+        n_patches = (img_size // patch_size) ** 2
+        patchfier = PatchEmbedding(patch_size, 3, 64)
+        positional_encodings = get_2d_positional_embeddings(
+            64, (img_size // patch_size, img_size // patch_size)
+        ).reshape(n_patches, 64)
+
         encoder = Encoder(
-            img_size=img_size,
-            patch_size=patch_size,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             hidden_dim=64,
             embed_dim=32,
             depth=2,
@@ -46,7 +60,6 @@ class TestEncoder:
         )
 
         images = torch.randn(batch_size, 3, img_size, img_size)
-        n_patches = (img_size // patch_size) ** 2
 
         # Create a random mask with the specified ratio
         num_mask = int(n_patches * mask_ratio)
@@ -59,35 +72,41 @@ class TestEncoder:
 
         assert encoded.shape == (batch_size, n_patches, encoder.out_proj.out_features)
 
-    @pytest.mark.parametrize(
-        "img_size,patch_size,expected_error",
-        [
-            (63, 8, "Image height 63 must be divisible by patch height 8"),
-            (64, 9, "Image height 64 must be divisible by patch height 9"),
-        ],
-    )
-    def test_invalid_image_size(self, img_size, patch_size, expected_error):
-        """Test error when image size is not divisible by patch size."""
-        with pytest.raises(ValueError, match=expected_error):
+    def test_invalid_positional_encoding_shape(self):
+        """Test error when positional encoding shape doesn't match expected
+        shape."""
+        patchfier = PatchEmbedding(8, 3, 64)
+        positional_encodings = torch.zeros(64, 32)  # Wrong shape
+
+        with pytest.raises(ValueError, match="Positional encoding shape mismatch"):
             Encoder(
-                img_size=img_size,
-                patch_size=patch_size,
-                embed_dim=64,
+                patchfier=patchfier,
+                num_patches=64,
+                positional_encodings=positional_encodings,
+                hidden_dim=64,
+                embed_dim=32,
                 depth=1,
                 num_heads=2,
             )
 
     def test_invalid_mask_shape(self):
         """Test error when mask shape doesn't match encoded image shape."""
+        n_patches = 64
+        patchfier = PatchEmbedding(8, 3, 64)
+        positional_encodings = get_2d_positional_embeddings(64, (8, 8)).reshape(
+            n_patches, 64
+        )
+
         encoder = Encoder(
-            img_size=64,
-            patch_size=8,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
+            hidden_dim=64,
             embed_dim=64,
             depth=1,
             num_heads=2,
         )
         images = torch.randn(2, 3, 64, 64)
-        n_patches = (64 // 8) ** 2
 
         # Create mask with incorrect shape
         masks = torch.zeros(2, n_patches - 1, dtype=torch.bool)
@@ -95,43 +114,24 @@ class TestEncoder:
         with pytest.raises(ValueError, match="Shape mismatch"):
             encoder(images, masks)
 
-    @pytest.mark.parametrize("img_size", [64])
-    @pytest.mark.parametrize("patch_size", [8])
-    def test_image_patch_size_variations(self, img_size, patch_size):
-        """Test that encoder handles both int and tuple for img_size and
-        patch_size."""
-        encoder = Encoder(
-            img_size=img_size,
-            patch_size=patch_size,
-            embed_dim=64,
-            depth=1,
-            num_heads=2,
-        )
-
-        # Regardless of the input format, we should be able to use the encoder
-        img_size = size_2d_to_int_tuple(img_size)
-        patch_size = size_2d_to_int_tuple(patch_size)
-        h, w = img_size
-
-        ph, pw = patch_size
-
-        images = torch.randn(1, 3, h, w)
-        encoded = encoder(images)
-
-        n_patches = (h // ph) * (w // pw)
-        assert encoded.shape == (1, n_patches, encoder.out_proj.out_features)
-
     def test_non_bool_mask(self):
         """Test error when mask tensor is not boolean."""
+        n_patches = 64
+        patchfier = PatchEmbedding(8, 3, 64)
+        positional_encodings = get_2d_positional_embeddings(64, (8, 8)).reshape(
+            n_patches, 64
+        )
+
         encoder = Encoder(
-            img_size=64,
-            patch_size=8,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
+            hidden_dim=64,
             embed_dim=64,
             depth=1,
             num_heads=2,
         )
         images = torch.randn(1, 3, 64, 64)
-        n_patches = (64 // 8) ** 2
 
         # Create mask with incorrect dtype (float instead of bool)
         masks = torch.zeros(1, n_patches, dtype=torch.float32)
@@ -139,16 +139,18 @@ class TestEncoder:
         with pytest.raises(ValueError, match="Mask tensor dtype must be bool"):
             encoder(images, masks)
 
-        # Test with int dtype
-        masks = torch.zeros(1, n_patches, dtype=torch.int32)
-
-        with pytest.raises(ValueError, match="Mask tensor dtype must be bool"):
-            encoder(images, masks)
-
     def test_clone(self):
+        n_patches = 64
+        patchfier = PatchEmbedding(8, 3, 64)
+        positional_encodings = get_2d_positional_embeddings(64, (8, 8)).reshape(
+            n_patches, 64
+        )
+
         encoder = Encoder(
-            img_size=64,
-            patch_size=8,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
+            hidden_dim=64,
             embed_dim=64,
             depth=1,
             num_heads=2,
@@ -161,30 +163,31 @@ class TestEncoder:
 
 class TestPredictor:
     @pytest.mark.parametrize("batch_size", [1])
-    @pytest.mark.parametrize("n_patches", [8, (8, 8)])
+    @pytest.mark.parametrize("n_patches", [64])
     @pytest.mark.parametrize("embed_dim", [32])
     @pytest.mark.parametrize("hidden_dim", [32])
     def test_forward(self, batch_size, n_patches, embed_dim, hidden_dim):
         """Test Predictor's forward pass."""
+        positional_encodings = get_2d_positional_embeddings(hidden_dim, (8, 8)).reshape(
+            n_patches, hidden_dim
+        )
+
         predictor = Predictor(
-            n_patches=n_patches,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             embed_dim=embed_dim,
             hidden_dim=hidden_dim,
             depth=2,
             num_heads=2,
         )
 
-        # Determine actual number of patches
-        n_patches = size_2d_to_int_tuple(n_patches)
-        n_patches_count = n_patches[0] * n_patches[1]
-
         # Create latents as if they came from encoder
-        latents = torch.randn(batch_size, n_patches_count, embed_dim)
+        latents = torch.randn(batch_size, n_patches, embed_dim)
 
         # Create target mask (e.g., 25% of patches are targets)
-        targets = torch.zeros(batch_size, n_patches_count, dtype=torch.bool)
+        targets = torch.zeros(batch_size, n_patches, dtype=torch.bool)
         for i in range(batch_size):
-            target_indices = torch.randperm(n_patches_count)[: n_patches_count // 4]
+            target_indices = torch.randperm(n_patches)[: n_patches // 4]
             targets[i, target_indices] = True
 
         predictions = predictor(latents, targets)
@@ -192,14 +195,35 @@ class TestPredictor:
         # Check output shape
         assert predictions.shape == (
             batch_size,
-            n_patches_count,
+            n_patches,
             embed_dim,
         )
 
+    def test_invalid_positional_encoding_shape(self):
+        """Test error when positional encoding shape doesn't match expected
+        shape."""
+        positional_encodings = torch.zeros(32, 64)  # Wrong shape for hidden_dim=32
+
+        with pytest.raises(ValueError, match="Positional encodings shape mismatch"):
+            Predictor(
+                num_patches=64,
+                positional_encodings=positional_encodings,
+                embed_dim=32,
+                hidden_dim=32,
+                depth=1,
+                num_heads=2,
+            )
+
     def test_invalid_target_shape(self):
         """Test error when target shape doesn't match latent shape."""
+        n_patches = 64
+        positional_encodings = get_2d_positional_embeddings(32, (8, 8)).reshape(
+            n_patches, 32
+        )
+
         predictor = Predictor(
-            n_patches=(8, 8),
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             embed_dim=32,
             hidden_dim=32,
             depth=1,
@@ -213,8 +237,14 @@ class TestPredictor:
 
     def test_non_bool_target(self):
         """Test error when target tensor is not boolean."""
+        n_patches = 64
+        positional_encodings = get_2d_positional_embeddings(32, (8, 8)).reshape(
+            n_patches, 32
+        )
+
         predictor = Predictor(
-            n_patches=(8, 8),
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             embed_dim=32,
             hidden_dim=32,
             depth=1,
@@ -228,12 +258,6 @@ class TestPredictor:
         with pytest.raises(ValueError, match="Target tensor dtype must be bool"):
             predictor(latents, targets)
 
-        # Test with int dtype
-        targets = torch.zeros(1, 64, dtype=torch.int32)
-
-        with pytest.raises(ValueError, match="Target tensor dtype must be bool"):
-            predictor(latents, targets)
-
 
 class TestJEPAIntegration:
     def test_encoder_predictor_integration(self):
@@ -243,26 +267,34 @@ class TestJEPAIntegration:
         img_size = 64
         patch_size = 8
         embed_dim = 32
+        hidden_dim = 64
 
         # Calculate grid dimensions
-        img_size_tuple = size_2d_to_int_tuple(img_size)
-        patch_size_tuple = size_2d_to_int_tuple(patch_size)
-        n_patches_h = img_size_tuple[0] // patch_size_tuple[0]
-        n_patches_w = img_size_tuple[1] // patch_size_tuple[1]
+        n_patches_h = img_size // patch_size
+        n_patches_w = img_size // patch_size
         n_patches = n_patches_h * n_patches_w
 
         # Initialize models with reduced complexity
+        patchfier = PatchEmbedding(patch_size, 3, hidden_dim)
+        positional_encodings = get_2d_positional_embeddings(
+            hidden_dim, (n_patches_h, n_patches_w)
+        ).reshape(n_patches, hidden_dim)
+
         encoder = Encoder(
-            img_size=img_size,
-            patch_size=patch_size,
-            hidden_dim=64,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
+            hidden_dim=hidden_dim,
             embed_dim=embed_dim,
             depth=2,
             num_heads=2,
         )
 
         predictor = Predictor(
-            n_patches=(n_patches_h, n_patches_w),
+            num_patches=n_patches,
+            positional_encodings=positional_encodings[
+                :, :32
+            ],  # Use first 32 dims for predictor
             embed_dim=embed_dim,
             hidden_dim=32,
             depth=1,
@@ -293,10 +325,16 @@ class TestAveragePoolInfer:
     @pytest.fixture
     def encoder(self):
         """Create a minimal working Encoder for testing."""
+        n_patches = 16
+        patchfier = PatchEmbedding(8, 3, 64)
+        positional_encodings = get_2d_positional_embeddings(64, (4, 4)).reshape(
+            n_patches, 64
+        )
+
         return Encoder(
-            img_size=32,
-            patch_size=8,
-            in_channels=3,
+            patchfier=patchfier,
+            num_patches=n_patches,
+            positional_encodings=positional_encodings,
             hidden_dim=64,
             embed_dim=32,
             depth=1,

--- a/tests/sample/models/test_jepa.py
+++ b/tests/sample/models/test_jepa.py
@@ -3,7 +3,7 @@ import torch
 
 from sample.models.components.patch_embedding import PatchEmbedding
 from sample.models.components.positional_embeddings import get_2d_positional_embeddings
-from sample.models.jepa import AveragePoolInfer, Encoder, Predictor
+from sample.models.jepa import AveragePoolInfer2d, Encoder, Predictor
 
 
 class TestEncoder:
@@ -344,7 +344,7 @@ class TestAveragePoolInfer:
     def test_basic_functionality(self, encoder):
         """Test basic pooling functionality."""
         # Setup
-        pooler = AveragePoolInfer(n_patches=(4, 4), kernel_size=2)
+        pooler = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=2)
         image = torch.randn(1, 3, 32, 32)
 
         # Encode and pool
@@ -355,7 +355,7 @@ class TestAveragePoolInfer:
 
     def test_different_batch_sizes(self, encoder):
         """Test with different batch sizes."""
-        pooler = AveragePoolInfer(n_patches=(4, 4), kernel_size=2)
+        pooler = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=2)
 
         # Test with batch size 2
         image_batch2 = torch.randn(2, 3, 32, 32)
@@ -369,7 +369,7 @@ class TestAveragePoolInfer:
 
     def test_no_batch_dimension(self, encoder):
         """Test with input tensor that has no batch dimension."""
-        pooler = AveragePoolInfer(n_patches=(4, 4), kernel_size=2)
+        pooler = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=2)
 
         # Create an image without batch dimension
         image = torch.randn(3, 32, 32)
@@ -382,7 +382,7 @@ class TestAveragePoolInfer:
 
     def test_multi_dimensional_batch(self, encoder):
         """Test with multi-dimensional batch."""
-        pooler = AveragePoolInfer(n_patches=(4, 4), kernel_size=2)
+        pooler = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=2)
 
         # Create a batch with multiple dimensions [2, 3, 3, 32, 32]
         image = torch.randn(2, 3, 3, 32, 32)
@@ -398,20 +398,20 @@ class TestAveragePoolInfer:
         # Original number of patches is 4x4=16
 
         # Test with kernel size 1 (no reduction)
-        pooler1 = AveragePoolInfer(n_patches=(4, 4), kernel_size=1)
+        pooler1 = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=1)
         image = torch.randn(1, 3, 32, 32)
         result1 = pooler1(encoder, image)
         assert result1.shape == (1, 16, 32)  # No reduction
 
         # Test with kernel size (2, 1) (reduction only in height)
-        pooler2 = AveragePoolInfer(n_patches=(4, 4), kernel_size=(2, 1))
+        pooler2 = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=(2, 1))
         result2 = pooler2(encoder, image)
         assert result2.shape == (1, 8, 32)  # 4x4 -> 2x4 = 8 patches
 
     def test_custom_stride(self, encoder):
         """Test with custom stride value."""
         # Test with stride different from kernel size
-        pooler = AveragePoolInfer(n_patches=(4, 4), kernel_size=2, stride=1)
+        pooler = AveragePoolInfer2d(n_patches=(4, 4), kernel_size=2, stride=1)
         image = torch.randn(1, 3, 32, 32)
         result = pooler(encoder, image)
 

--- a/tests/sample/trainers/test_jepa.py
+++ b/tests/sample/trainers/test_jepa.py
@@ -12,25 +12,38 @@ from torch.utils.data import DataLoader
 
 from sample.data import BufferName, DataKey
 from sample.models import ModelName
-from sample.models.image_jepa import Encoder, Predictor
-from sample.trainers.image_jepa import ImageJEPATrainer, MultiBlockMaskCollator
+from sample.models.components.patch_embedding import PatchEmbedding
+from sample.models.components.positional_embeddings import get_2d_positional_embeddings
+from sample.models.jepa import Encoder, Predictor
+from sample.trainers.jepa import JEPATrainer, MultiBlockMaskCollator2d
 from tests.sample.helpers import parametrize_device
 
 
-class TestImageJEPATrainer:
+class TestJEPATrainer:
     IMAGE_SIZE = 64
     PATCH_SIZE = 8
     CHANNELS = 3
     EMBED_DIM = 16
+    HIDDEN_DIM = 128
     N_PATCHES = IMAGE_SIZE // PATCH_SIZE
 
     @pytest.fixture
-    def context_encoder(self):
+    def patchfier(self):
+        return PatchEmbedding(self.PATCH_SIZE, self.CHANNELS, self.HIDDEN_DIM)
+
+    @pytest.fixture
+    def positional_encodings(self):
+        return get_2d_positional_embeddings(
+            self.HIDDEN_DIM, (self.N_PATCHES, self.N_PATCHES)
+        ).reshape(-1, self.HIDDEN_DIM)
+
+    @pytest.fixture
+    def context_encoder(self, patchfier, positional_encodings):
         return Encoder(
-            img_size=self.IMAGE_SIZE,
-            patch_size=self.PATCH_SIZE,
-            in_channels=self.CHANNELS,
-            hidden_dim=128,
+            patchfier=patchfier,
+            num_patches=self.N_PATCHES * self.N_PATCHES,
+            positional_encodings=positional_encodings,
+            hidden_dim=self.HIDDEN_DIM,
             embed_dim=self.EMBED_DIM,
             depth=1,
             num_heads=2,
@@ -41,9 +54,16 @@ class TestImageJEPATrainer:
         return context_encoder.clone()
 
     @pytest.fixture
-    def predictor(self):
+    def predictor_positional_encodings(self):
+        return get_2d_positional_embeddings(
+            64, (self.N_PATCHES, self.N_PATCHES)
+        ).reshape(-1, 64)
+
+    @pytest.fixture
+    def predictor(self, predictor_positional_encodings):
         return Predictor(
-            n_patches=self.N_PATCHES,
+            num_patches=self.N_PATCHES * self.N_PATCHES,
+            positional_encodings=predictor_positional_encodings,
             embed_dim=self.EMBED_DIM,
             hidden_dim=64,
             depth=1,
@@ -72,7 +92,7 @@ class TestImageJEPATrainer:
             DataLoader,
             batch_size=2,
             shuffle=True,
-            collate_fn=MultiBlockMaskCollator(
+            collate_fn=MultiBlockMaskCollator2d(
                 input_size=self.IMAGE_SIZE,
                 patch_size=self.PATCH_SIZE,
             ),
@@ -85,16 +105,19 @@ class TestImageJEPATrainer:
 
     @pytest.fixture
     def trainer(self, partial_dataloader, partial_optimizer, mocker: MockerFixture):
-        mocker.patch("sample.trainers.image_jepa.mlflow")
-        return ImageJEPATrainer(
+        mocker.patch("sample.trainers.jepa.mlflow")
+        return JEPATrainer(
             partial_dataloader,
             partial_optimizer,
+            context_encoder_name=ModelName.IMAGE_JEPA_CONTEXT_ENCODER,
+            target_encoder_name=ModelName.IMAGE_JEPA_TARGET_ENCODER,
+            predictor_name=ModelName.IMAGE_JEPA_PREDICTOR,
             min_buffer_size=4,
             min_new_data_count=2,
         )
 
     @parametrize_device
-    def test_run(self, device, data_buffers, models, trainer: ImageJEPATrainer):
+    def test_run(self, device, data_buffers, models, trainer: JEPATrainer):
         """Test JEPA Trainer workflow."""
         models = {
             name: TorchTrainingModel(m, has_inference_model=False, device=device)
@@ -121,7 +144,7 @@ class TestImageJEPATrainer:
         assert trainer.run() is False
         assert trainer.global_step == global_step
 
-    def test_save_and_load_state(self, trainer: ImageJEPATrainer, tmp_path: Path):
+    def test_save_and_load_state(self, trainer: JEPATrainer, tmp_path: Path):
         trainer_path = tmp_path / "trainer"
         trainer.save_state(trainer_path)
         global_step = trainer.global_step
@@ -132,7 +155,7 @@ class TestImageJEPATrainer:
         assert trainer.global_step == global_step
 
 
-class TestMultiBlockMaskCollator:
+class TestMultiBlockMaskCollator2d:
     @pytest.mark.parametrize("image_size", [224])
     @pytest.mark.parametrize("patch_size", [16])
     @pytest.mark.parametrize("min_keep", [10])
@@ -140,7 +163,7 @@ class TestMultiBlockMaskCollator:
     def test_sample_mask_rectangle(self, image_size, patch_size, min_keep, mask_scale):
         """Test that the sampled mask rectangle has valid dimensions and
         follows constraints."""
-        collator = MultiBlockMaskCollator(
+        collator = MultiBlockMaskCollator2d(
             input_size=image_size,
             patch_size=patch_size,
             mask_scale=mask_scale,
@@ -187,7 +210,7 @@ class TestMultiBlockMaskCollator:
         assert image_size % patch_size == 0
 
         # Initialize collator
-        collator = MultiBlockMaskCollator(
+        collator = MultiBlockMaskCollator2d(
             input_size=(image_size, image_size),
             patch_size=(patch_size, patch_size),
             n_masks=n_masks,
@@ -258,7 +281,7 @@ class TestMultiBlockMaskCollator:
         """Test the sample_masks_and_target method for correct output shapes
         and properties."""
         image_size, patch_size = 224, 16
-        collator = MultiBlockMaskCollator(
+        collator = MultiBlockMaskCollator2d(
             input_size=(image_size, image_size),
             patch_size=(patch_size, patch_size),
             n_masks=4,
@@ -290,7 +313,7 @@ class TestMultiBlockMaskCollator:
     def test_n_patches_property(self):
         """Test that the n_patches property returns the correct value."""
         image_size, patch_size = 224, 16
-        collator = MultiBlockMaskCollator(
+        collator = MultiBlockMaskCollator2d(
             input_size=(image_size, image_size),
             patch_size=(patch_size, patch_size),
         )
@@ -300,7 +323,7 @@ class TestMultiBlockMaskCollator:
 
     def test_step_method(self):
         """Test that the step method increments the counter properly."""
-        collator = MultiBlockMaskCollator(
+        collator = MultiBlockMaskCollator2d(
             input_size=224,
             patch_size=16,
         )
@@ -322,7 +345,7 @@ class TestMultiBlockMaskCollator:
     def test_invalid_dimensions(self, input_size, patch_size, expected_error):
         """Test error when dimensions are invalid."""
         with pytest.raises(ValueError, match=expected_error):
-            MultiBlockMaskCollator(
+            MultiBlockMaskCollator2d(
                 input_size=input_size,
                 patch_size=patch_size,
             )
@@ -338,7 +361,7 @@ class TestMultiBlockMaskCollator:
     def test_invalid_mask_scale(self, mask_scale, expected_error):
         """Test error when mask_scale is invalid."""
         with pytest.raises(ValueError, match=expected_error):
-            MultiBlockMaskCollator(
+            MultiBlockMaskCollator2d(
                 input_size=224,
                 patch_size=16,
                 mask_scale=mask_scale,
@@ -349,7 +372,7 @@ class TestMultiBlockMaskCollator:
         with pytest.raises(
             ValueError, match="min_keep .* must be less than or equal to total patches"
         ):
-            MultiBlockMaskCollator(
+            MultiBlockMaskCollator2d(
                 input_size=224,
                 patch_size=16,
                 min_keep=1000,  # Much larger than available patches

--- a/tests/sample/trainers/test_jepa.py
+++ b/tests/sample/trainers/test_jepa.py
@@ -109,12 +109,24 @@ class TestJEPATrainer:
         return JEPATrainer(
             partial_dataloader,
             partial_optimizer,
-            context_encoder_name=ModelName.IMAGE_JEPA_CONTEXT_ENCODER,
-            target_encoder_name=ModelName.IMAGE_JEPA_TARGET_ENCODER,
-            predictor_name=ModelName.IMAGE_JEPA_PREDICTOR,
+            modality="image",
             min_buffer_size=4,
             min_new_data_count=2,
         )
+
+    @pytest.mark.parametrize("modality", ["image", "audio"])
+    def test_initilization(
+        self, modality, partial_dataloader, partial_optimizer, mocker: MockerFixture
+    ):
+        mocker.patch("sample.trainers.jepa.mlflow")
+        trainer = JEPATrainer(
+            partial_dataloader,
+            partial_optimizer,
+            modality=modality,
+            min_buffer_size=4,
+            min_new_data_count=2,
+        )
+        assert trainer.log_prefix == f"{modality}-jepa"
 
     @parametrize_device
     def test_run(self, device, data_buffers, models, trainer: JEPATrainer):

--- a/tests/sample/trainers/test_jepa.py
+++ b/tests/sample/trainers/test_jepa.py
@@ -15,7 +15,12 @@ from sample.models import ModelName
 from sample.models.components.patch_embedding import PatchEmbedding
 from sample.models.components.positional_embeddings import get_2d_positional_embeddings
 from sample.models.jepa import Encoder, Predictor
-from sample.trainers.jepa import JEPATrainer, MultiBlockMaskCollator2d
+from sample.trainers.jepa import (
+    AUDIO_CONFIG,
+    IMAGE_CONFIG,
+    JEPATrainer,
+    MultiBlockMaskCollator2d,
+)
 from tests.sample.helpers import parametrize_device
 
 
@@ -109,24 +114,23 @@ class TestJEPATrainer:
         return JEPATrainer(
             partial_dataloader,
             partial_optimizer,
-            modality="image",
+            **IMAGE_CONFIG,
             min_buffer_size=4,
             min_new_data_count=2,
         )
 
-    @pytest.mark.parametrize("modality", ["image", "audio"])
+    @pytest.mark.parametrize("modality_cfg", [IMAGE_CONFIG, AUDIO_CONFIG])
     def test_initilization(
-        self, modality, partial_dataloader, partial_optimizer, mocker: MockerFixture
+        self, modality_cfg, partial_dataloader, partial_optimizer, mocker: MockerFixture
     ):
         mocker.patch("sample.trainers.jepa.mlflow")
-        trainer = JEPATrainer(
+        JEPATrainer(
             partial_dataloader,
             partial_optimizer,
-            modality=modality,
+            **modality_cfg,
             min_buffer_size=4,
             min_new_data_count=2,
         )
-        assert trainer.log_prefix == f"{modality}-jepa"
 
     @parametrize_device
     def test_run(self, device, data_buffers, models, trainer: JEPATrainer):

--- a/tests/sample/trainers/test_jepa.py
+++ b/tests/sample/trainers/test_jepa.py
@@ -46,7 +46,6 @@ class TestJEPATrainer:
     def context_encoder(self, patchfier, positional_encodings):
         return Encoder(
             patchfier=patchfier,
-            num_patches=self.N_PATCHES * self.N_PATCHES,
             positional_encodings=positional_encodings,
             hidden_dim=self.HIDDEN_DIM,
             embed_dim=self.EMBED_DIM,
@@ -67,7 +66,6 @@ class TestJEPATrainer:
     @pytest.fixture
     def predictor(self, predictor_positional_encodings):
         return Predictor(
-            num_patches=self.N_PATCHES * self.N_PATCHES,
             positional_encodings=predictor_positional_encodings,
             embed_dim=self.EMBED_DIM,
             hidden_dim=64,


### PR DESCRIPTION
# Pull Request

## Description

AudioJEPA, ImageJEPAでアーキテクチャやTrainerは共通になるので、Patchfierや positional encoding vectorを依存性抽出することで汎用化しました。

いくつかの ImageJEPA向けに作っていた機能は `2d` suffixをつけてエスケープしています。

<!-- Purpose of changes or related Issue number -->

<!-- If there are UI changes, screenshots for comparison would be helpful -->

## Impact on Other Code/Features

- [x] None
- [ ] Yes

<!-- If yes, please describe -->

<!-- For example: "Changes to this function affect that feature" etc. -->

## Pre-submit Checklist

<!-- Items to check before submitting PR -->

- [x] Is the title clear and descriptive, and does the description concisely explain the PR?
- [x] Have you confirmed your PR handles one specific change rather than bundling different changes together?
- [x] Have you listed all changes introduced in this PR?
- [x] Have you tested the PR locally using the `make run` command?

## Additional Notes

<!-- Points to focus on during review, notes for local testing, etc. -->
