### PR TITLE
TemporalEncoderをインスタンス化するファクトリ関数を実装

### DIFF
--- a/src/sample/models/temporal_encoder.py
+++ b/src/sample/models/temporal_encoder.py
@@ -1,10 +1,10 @@
 from collections.abc import Mapping
-from typing import override
+from typing import NamedTuple, override
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pamiq_core.torch import get_device
+from pamiq_core.torch import TorchTrainingModel, get_device
 from torch import Tensor
 from torch.distributions import Distribution
 
@@ -46,25 +46,10 @@ class TemporalEncoder(nn.Module):
         self.core_model = core_model
         self.obs_hat_dist_heads = nn.ModuleDict(obs_hat_dist_heads)
 
-    @override
-    def forward(
+    def _common_flow(
         self, observations: Mapping[str, Tensor], hidden: Tensor
-    ) -> tuple[Tensor, Tensor, Mapping[str, Distribution]]:
-        """Forward path of multimodal temporal encoder.
-
-        Args:
-            observations: Dictionary mapping modality names to observation tensors
-            hidden: Hidden state tensor for temporal module
-
-        Returns:
-            A tuple containing:
-                - Embedded observation representation
-                - Next hidden state
-                - Dictionary of predicted observation distributions for each modality
-
-        Raises:
-            KeyError: If keys between observation_flattens and observations are not matched.
-        """
+    ) -> tuple[Tensor, Tensor]:
+        """Common data flow of Temporal Encoder."""
         if observations.keys() != self.observation_flattens.keys():
             raise KeyError("Observations keys are not matched!")
 
@@ -74,13 +59,34 @@ class TemporalEncoder(nn.Module):
 
         x = self.flattened_obses_projection(torch.cat(obs_flats, dim=-1))
         x, next_hidden = self.core_model(x, hidden)
+        return x, next_hidden
+
+    @override
+    def forward(
+        self, observations: Mapping[str, Tensor], hidden: Tensor
+    ) -> tuple[Mapping[str, Distribution], Tensor]:
+        """Forward path of multimodal temporal encoder.
+
+        Args:
+            observations: Dictionary mapping modality names to observation tensors
+            hidden: Hidden state tensor for temporal module
+
+        Returns:
+            A tuple containing:
+                - Dictionary of predicted observation distributions for each modality
+                - Next hidden state
+
+        Raises:
+            KeyError: If keys between observation_flattens and observations are not matched.
+        """
+        x, next_hidden = self._common_flow(observations, hidden)
         obs_hat_dists = {k: layer(x) for k, layer in self.obs_hat_dist_heads.items()}
-        return x, next_hidden, obs_hat_dists
+        return obs_hat_dists, next_hidden
 
     @override
     def __call__(
         self, observations: Mapping[str, Tensor], hidden: Tensor
-    ) -> tuple[Tensor, Tensor, Mapping[str, Distribution]]:
+    ) -> tuple[Mapping[str, Distribution], Tensor]:
         """Call forward method with type checking.
 
         This method is an override of nn.Module.__call__ to provide
@@ -104,6 +110,84 @@ class TemporalEncoder(nn.Module):
         """
         device = get_device(self)
         observations = {k: v.to(device) for k, v in observations.items()}
-        x, next_hidden, _ = self(observations, hidden.to(device))
+        x, next_hidden = self._common_flow(observations, hidden.to(device))
         x = F.layer_norm(x, x.shape[-1:])
         return x, next_hidden
+
+
+class ObsInfo(NamedTuple):
+    """Configuration for observation processing in temporal encoder.
+
+    This named tuple defines the dimensions and feature stack configuration for
+    each modality processed by the temporal encoder.
+
+    Attributes:
+        dim_in: Input dimension of the observation.
+        dim_out: Output dimension after feature transformation.
+        num_tokens: Number of tokens of observation.
+    """
+
+    dim_in: int
+    dim_out: int
+    num_tokens: int
+
+
+def instantiate(
+    obs_infos: Mapping[str, ObsInfo | tuple[int, int, int]],
+    depth: int,
+    dim: int,
+    dim_ff_hidden: int,
+    dropout: float,
+    device: torch.device | None = None,
+    dtype: torch.dtype | None = None,
+) -> TorchTrainingModel[TemporalEncoder]:
+    """Create a temporal encoder model with the specified configuration.
+
+    This factory function instantiates a TemporalEncoder model with stacked feature
+    processing for each modality (expected JEPA output.), and wraps it in a TorchTrainingModel for use with
+    the PAMIQ-Core framework.
+
+    Args:
+        obs_infos: Dictionary mapping modality names to their observation configuration.
+        depth: Number of recurrent layers in the core QLSTM model.
+        dim: Hidden dimension of the encoder.
+        dim_ff_hidden: Hidden dimension of the feed-forward networks in QLSTM.
+        dropout: Dropout rate for regularization.
+        device: PyTorch device to place the model on. Defaults to None (uses current device).
+        dtype: PyTorch data type for the model parameters. Defaults to None (uses default dtype).
+
+    Returns:
+        TorchTrainingModel containing the configured temporal encoder.
+    """
+    from .components.deterministic_normal import FCDeterministicNormalHead
+    from .components.qlstm import QLSTM
+    from .components.stacked_features import LerpStackedFeatures, ToStackedFeatures
+
+    obs_flattens = {}
+    obs_hat_heads = {}
+    flattened_size = 0
+    for name, info in obs_infos.items():
+        info = ObsInfo(*info)
+        obs_flattens[name] = LerpStackedFeatures(
+            info.dim_in, info.dim_out, info.num_tokens
+        )
+
+        obs_hat_heads[name] = nn.Sequential(
+            ToStackedFeatures(dim, info.dim_in, info.num_tokens),
+            FCDeterministicNormalHead(info.dim_in, info.dim_in),
+        )
+        flattened_size += info.dim_out
+
+    encoder = TemporalEncoder(
+        obs_flattens,
+        nn.Linear(flattened_size, dim),
+        QLSTM(depth, dim, dim_ff_hidden, dropout),
+        obs_hat_heads,
+    )
+    return TorchTrainingModel(
+        encoder,
+        has_inference_model=True,
+        inference_procedure=TemporalEncoder.infer,
+        device=device,
+        dtype=dtype,
+    )

--- a/src/sample/trainers/temporal_encoder.py
+++ b/src/sample/trainers/temporal_encoder.py
@@ -151,7 +151,7 @@ class TemporalEncoderTrainer(TorchTrainer):
                 self.optimizers[OPTIMIZER_NAME].zero_grad()
 
                 # Forward pass
-                _, _, obs_hat_dists = self.temporal_encoder.model(observations, hiddens)
+                obs_hat_dists, _ = self.temporal_encoder.model(observations, hiddens)
 
                 # Calculate losses for each modality
                 total_loss = torch.tensor(0.0, device=device)

--- a/tests/sample/models/test_temporal_encoder.py
+++ b/tests/sample/models/test_temporal_encoder.py
@@ -89,10 +89,9 @@ class TestTemporalEncoder:
 
     def test_forward(self, encoder, observations, hidden):
         """Test forward pass of TemporalEncoder."""
-        x, next_hidden, obs_hat_dists = encoder(observations, hidden)
+        obs_hat_dists, next_hidden = encoder(observations, hidden)
 
         # Check output shapes
-        assert x.shape == (self.BATCH_SIZE, self.SEQ_LEN, self.HIDDEN_DIM)
         assert next_hidden.shape == (
             self.BATCH_SIZE,
             self.HIDDEN_DEPTH,


### PR DESCRIPTION
# Pull Request

## Description

TemporalEncoderをインスタンス化するための関数を実装しました。
JEPAの (token x feature) の出力を観測に受け取ることを想定しています。

また、 Temporal Encoder処理が少々冗長だったので、 `_common_flow`を実装し、シグネチャを改良しました。

<!-- Purpose of changes or related Issue number -->

<!-- If there are UI changes, screenshots for comparison would be helpful -->

## Impact on Other Code/Features

- [ ] None
- [ ] Yes

<!-- If yes, please describe -->

<!-- For example: "Changes to this function affect that feature" etc. -->

## Pre-submit Checklist

<!-- Items to check before submitting PR -->

- [ ] Is the title clear and descriptive, and does the description concisely explain the PR?
- [ ] Have you confirmed your PR handles one specific change rather than bundling different changes together?
- [ ] Have you listed all changes introduced in this PR?
- [ ] Have you tested the PR locally using the `make run` command?

## Additional Notes

<!-- Points to focus on during review, notes for local testing, etc. -->
