### PR TITLE
JEPAのモデルの1次元用コンポーネントを追加

### DIFF
--- a/src/sample/models/components/positional_embeddings.py
+++ b/src/sample/models/components/positional_embeddings.py
@@ -27,6 +27,21 @@ def get_2d_positional_embeddings(embed_dim: int, grid_size: size_2d) -> torch.Te
     return torch.from_numpy(positional_embeddings).float()
 
 
+def get_1d_positional_embeddings(embed_dim: int, length: int) -> torch.Tensor:
+    """
+    Args:
+        embed_dim: dim of positional embeddings.
+        length: length of positional embeddings.
+    Returns:
+        positional embeddings (shape: [length, embed_dim]).
+    """
+
+    pos_emb = get_2d_positional_embeddings(
+        embed_dim, (1, length)
+    )  # [1, length, embed_dim]
+    return pos_emb.squeeze(0)
+
+
 def _get_2d_sincos_positional_embeddings_from_grid(
     embed_dim: int, grid: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -5,6 +5,7 @@ Architecture (JEPA) model.
 """
 
 import copy
+from collections.abc import Callable
 from typing import Self, override
 
 import torch
@@ -23,7 +24,7 @@ class Encoder(nn.Module):
 
     def __init__(
         self,
-        patchfier: nn.Module,
+        patchfier: Callable[[torch.Tensor], torch.Tensor],
         positional_encodings: torch.Tensor,
         hidden_dim: int = 768,
         embed_dim: int = 384,
@@ -263,25 +264,63 @@ class Predictor(nn.Module):
         return super().__call__(latents, targets)
 
 
-class AveragePoolInfer2d:
-    """Applies average pooling to encoded 2d patches (such as image) from a
-    JEPA encoder."""
+class AveragePoolInfer:
+    """Applies average pooling to encoded N-dimensional patches from a JEPA
+    encoder."""
 
     def __init__(
-        self, num_patches: size_2d, kernel_size: size_2d, stride: size_2d | None = None
+        self,
+        ndim: int,
+        num_patches: int | tuple[int, ...],
+        kernel_size: int | tuple[int, ...],
+        stride: int | tuple[int, ...] | None = None,
     ) -> None:
         """Initialize the average pooling inference wrapper.
 
         Args:
-            num_patches: Number of patches in the original encoded representation,
-                either as a single integer for square arrangements or a tuple (height, width).
-            kernel_size: Size of the pooling kernel, either as a single integer
-                for square kernels or a tuple (height, width).
-            stride: Stride of the pooling operation, either as a single integer
-                or a tuple (height, width). If None, defaults to kernel_size.
+            ndim: Number of spatial dimensions (1, 2, or 3).
+            num_patches: Number of patches in the original encoded representation.
+                If int, assumes uniform patches across all dimensions.
+                If tuple, length must match ndim.
+            kernel_size: Size of the pooling kernel.
+                If int, uses same size for all dimensions.
+                If tuple, length must match ndim.
+            stride: Stride of the pooling operation.
+                If None, defaults to kernel_size.
+                If int, uses same stride for all dimensions.
+                If tuple, length must match ndim.
+
+        Raises:
+            ValueError:
+                - If ndim is not 1, 2, or 3.
+                - If num_patches, kernel_size, stride tuple length doesn't match ndim.
         """
-        self.num_patches = size_2d_to_int_tuple(num_patches)
-        self.pool = nn.AvgPool2d(kernel_size, stride)
+        if ndim not in (1, 2, 3):
+            raise ValueError(f"ndim must be 1, 2, or 3, got {ndim}")
+
+        self.ndim = ndim
+
+        def validate_and_normalize(obj: int | tuple[int, ...]) -> tuple[int, ...]:
+            if isinstance(obj, int):
+                return (obj,) * ndim
+            if len(obj) != ndim:
+                raise ValueError(f"Expected tuple of length {ndim}, got {len(obj)}")
+            return obj
+
+        # Validate and normalize num_patches
+        self.num_patches = validate_and_normalize(num_patches)
+        kernel_size = validate_and_normalize(kernel_size)
+        if stride is not None:
+            stride = validate_and_normalize(stride)
+
+        # Create appropriate pooling layer
+        match ndim:
+            case 1:
+                self.pool = nn.AvgPool1d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
+            case 2:
+                self.pool = nn.AvgPool2d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
+            case 3:
+                self.pool = nn.AvgPool3d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
 
     def __call__(self, encoder: Encoder, data: torch.Tensor) -> torch.Tensor:
         """Process data through the encoder and apply average pooling to the
@@ -289,34 +328,40 @@ class AveragePoolInfer2d:
 
         Args:
             encoder: JEPA Encoder instance.
-            data: 2d tensor with shape [*batch, dim, patch] where patch = height * width.
+            data: N-dimensional tensor with shape [*batch, dim, *spatial_dims].
 
         Returns:
             Tensor with shape [*batch, patch', dim] where patch' is the reduced number
             of patches after pooling.
-            Output shape detail: https://docs.pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
         """
         device = get_device(encoder)
         data = data.to(device)
 
-        if no_batch := data.ndim < 4:
+        # Handle batch dimension
+        data_ndim = 1 + self.ndim  # dim + spatial dimensions
+        if no_batch := data.ndim < data_ndim:
             data = data.unsqueeze(0)
 
-        batch_shape = data.shape[:-3]
-        data = data.reshape(-1, *data.shape[-3:])  # [batch', dim, height, width]
+        batch_shape = data.shape[:-data_ndim]
+        data = data.reshape(-1, *data.shape[-data_ndim:])
 
+        # Encode
         x = encoder(data)  # [batch', patch, dim]
         x = torch.nn.functional.layer_norm(x, (x.size(-1),))
 
         x = x.transpose(-1, -2)  # [batch', dim, patch]
 
-        x = x.reshape(
-            -1, x.size(-2), *self.num_patches
-        )  # [batch', dim, patch_v, patch_h]
-        x: torch.Tensor = self.pool(x)  # [batch', dim, patch_h', patch_w']
-        x = x.flatten(-2).transpose(-1, -2)  # [batch', patch', dim]
+        # Reshape for pooling: [batch', dim, *spatial_patch_dims]
+        x = x.reshape(-1, x.size(-2), *self.num_patches)
 
-        x = x.reshape(*batch_shape, *x.shape[-2:])  # [*batch, patch', dim]
+        # Apply pooling
+        x: torch.Tensor = self.pool(x)
+
+        # Flatten spatial dimensions and transpose back
+        x = x.flatten(-self.ndim).transpose(-1, -2)  # [batch', patch', dim]
+
+        # Restore original batch shape
+        x = x.reshape(*batch_shape, *x.shape[-2:])
         if no_batch:
             x = x.squeeze(0)
         return x

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -6,7 +6,7 @@ Architecture (JEPA) model.
 
 import copy
 from collections.abc import Callable
-from typing import Self, override
+from typing import Literal, Self, override
 
 import torch
 import torch.nn as nn
@@ -263,12 +263,12 @@ class Predictor(nn.Module):
 
 
 class AveragePoolInfer:
-    """Applies average pooling to encoded N-dimensional patches from a JEPA
-    encoder."""
+    """Applies average pooling to encoded 1d (audio) or 2d (image) patches from
+    a JEPA encoder."""
 
     def __init__(
         self,
-        ndim: int,
+        ndim: Literal[1, 2],
         num_patches: int | tuple[int, ...],
         kernel_size: int | tuple[int, ...],
         stride: int | tuple[int, ...] | None = None,
@@ -276,7 +276,7 @@ class AveragePoolInfer:
         """Initialize the average pooling inference wrapper.
 
         Args:
-            ndim: Number of spatial dimensions (1, 2, or 3).
+            ndim: Number of spatial dimensions (1 or 2 are supported).
             num_patches: Number of patches in the original encoded representation.
                 If int, assumes uniform patches across all dimensions.
                 If tuple, length must match ndim.
@@ -290,11 +290,8 @@ class AveragePoolInfer:
 
         Raises:
             ValueError:
-                - If ndim is not 1, 2, or 3.
                 - If num_patches, kernel_size, stride tuple length doesn't match ndim.
         """
-        if ndim not in (1, 2, 3):
-            raise ValueError(f"ndim must be 1, 2, or 3, got {ndim}")
 
         self.ndim = ndim
 
@@ -317,8 +314,6 @@ class AveragePoolInfer:
                 self.pool = nn.AvgPool1d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
             case 2:
                 self.pool = nn.AvgPool2d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
-            case 3:
-                self.pool = nn.AvgPool3d(kernel_size, stride)  # pyright: ignore[reportArgumentType, ]
 
     def __call__(self, encoder: Encoder, data: torch.Tensor) -> torch.Tensor:
         """Process data through the encoder and apply average pooling to the

--- a/src/sample/models/jepa.py
+++ b/src/sample/models/jepa.py
@@ -12,8 +12,6 @@ import torch
 import torch.nn as nn
 from pamiq_core.torch import get_device
 
-from sample.utils import size_2d, size_2d_to_int_tuple
-
 from .components.transformer import Transformer
 from .utils import init_weights
 

--- a/tests/sample/models/components/test_positional_embeddings.py
+++ b/tests/sample/models/components/test_positional_embeddings.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from sample.models.components.positional_embeddings import (
+    get_1d_positional_embeddings,
     get_2d_positional_embeddings,
     size_2d,
 )
@@ -45,6 +46,26 @@ def test_get_2d_positional_embeddings(
         positional_embeddings.shape[1] == expected_grid_size_w
     ), "grid size (width) mismatch."
     assert positional_embeddings.shape[2] == embed_dim, "dim mismatch."
+    assert torch.all(
+        torch.abs(positional_embeddings) <= 1.0
+    ), "some invalid values of sin and cos function"
+
+
+@pytest.mark.parametrize("embed_dim", [384, 768])
+@pytest.mark.parametrize("length", [1, 10, 100, 256])
+def test_get_1d_positional_embeddings(embed_dim: int, length: int):
+    """Test that get_1d_positional_embeddings returns correct shape and valid
+    values."""
+    positional_embeddings = get_1d_positional_embeddings(
+        embed_dim=embed_dim, length=length
+    )
+
+    # Check dimensions
+    assert positional_embeddings.ndim == 2, "positional_embeddings should be 2D"
+    assert positional_embeddings.shape[0] == length, "length dimension mismatch"
+    assert positional_embeddings.shape[1] == embed_dim, "embed_dim dimension mismatch"
+
+    # Check value range (sin/cos values should be between -1 and 1)
     assert torch.all(
         torch.abs(positional_embeddings) <= 1.0
     ), "some invalid values of sin and cos function"

--- a/tests/sample/models/test_jepa.py
+++ b/tests/sample/models/test_jepa.py
@@ -385,7 +385,6 @@ class TestAveragePoolInfer:
     @pytest.mark.parametrize(
         "ndim,num_patches,kernel_size,stride,error_msg",
         [
-            (4, 16, 2, None, "ndim must be 1, 2, or 3"),
             (2, (4, 4, 4), 2, None, "Expected tuple of length 2, got 3"),
             (2, 16, (2, 2, 2), None, "Expected tuple of length 2, got 3"),
             (2, 16, 2, (1, 1, 1), "Expected tuple of length 2, got 3"),
@@ -406,7 +405,6 @@ class TestAveragePoolInfer:
         [
             (1, nn.AvgPool1d),
             (2, nn.AvgPool2d),
-            (3, nn.AvgPool3d),
         ],
     )
     def test_pooling_layer_selection(self, ndim, expected_pool_type):
@@ -486,9 +484,3 @@ class TestAveragePoolInfer:
         image = torch.randn(1, 3, 64, 64)
         result = pooler(encoder_2d, image)
         assert result.shape == (1, 32, 32)  # 8x4 = 32
-
-    def test_3d_pooling_init(self):
-        """Test 3D pooling initialization."""
-        pooler = AveragePoolInfer(ndim=3, num_patches=(4, 4, 4), kernel_size=2)
-        assert pooler.num_patches == (4, 4, 4)
-        assert isinstance(pooler.pool, nn.AvgPool3d)


### PR DESCRIPTION
# Pull Request

## Description

* get_1d_positional_embeddingsを実装しました。
* AveragePoolInferを1,2,3次元に対して汎用化しました。

<!-- Purpose of changes or related Issue number -->

<!-- If there are UI changes, screenshots for comparison would be helpful -->

## Impact on Other Code/Features

- [x] None
- [ ] Yes

<!-- If yes, please describe -->

<!-- For example: "Changes to this function affect that feature" etc. -->

## Pre-submit Checklist

<!-- Items to check before submitting PR -->

- [x] Is the title clear and descriptive, and does the description concisely explain the PR?
- [x] Have you confirmed your PR handles one specific change rather than bundling different changes together?
- [x] Have you listed all changes introduced in this PR?
- [x] Have you tested the PR locally using the `make run` command?

## Additional Notes

<!-- Points to focus on during review, notes for local testing, etc. -->
